### PR TITLE
Update 'bitcoin' dependency to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "electrum2descriptors"
 path = "src/bin.rs"
 
 [dependencies]
-bitcoin = "0.29"
+bitcoin = "0.30"
 
 # Optional dependencies
 serde = { version = "1", optional = true }
@@ -30,10 +30,10 @@ serde_json = { version = "1", optional = true }
 regex = { version = "1", optional = true }
 
 [dev-dependencies]
-miniscript = "8"
-bdk = "0.24"
-rstest = "0.12"
-tempfile = "3.3"
+miniscript = "9"
+bdk = "0.28"
+rstest = "0.17"
+tempfile = "3.5"
 
 [features]
 default = [ "wallet_file" ]

--- a/src/electrum_extended_priv_key.rs
+++ b/src/electrum_extended_priv_key.rs
@@ -1,7 +1,7 @@
 use crate::ElectrumExtendedKey;
 use bitcoin::secp256k1;
-use bitcoin::util::base58;
-use bitcoin::util::bip32::{ChainCode, ChildNumber, ExtendedPrivKey, Fingerprint};
+use bitcoin::base58;
+use bitcoin::bip32::{ChainCode, ChildNumber, ExtendedPrivKey, Fingerprint};
 use bitcoin::Network;
 use std::convert::TryInto;
 use std::str::FromStr;
@@ -90,7 +90,7 @@ impl FromStr for ElectrumExtendedPrivKey {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let data = base58::from_check(s).map_err(|e| e.to_string())?;
+        let data = base58::decode_check(s).map_err(|e| e.to_string())?;
 
         if data.len() != 78 {
             return Err(base58::Error::InvalidLength(data.len()).to_string());
@@ -104,9 +104,9 @@ impl FromStr for ElectrumExtendedPrivKey {
         let xprv = ExtendedPrivKey {
             network,
             depth: data[4],
-            parent_fingerprint: Fingerprint::from(&data[5..9]),
+            parent_fingerprint: Fingerprint::from(&data[5..9].try_into().unwrap()),
             child_number,
-            chain_code: ChainCode::from(&data[13..45]),
+            chain_code: ChainCode::from(&data[13..45].try_into().unwrap()),
             private_key: key,
         };
         Ok(ElectrumExtendedPrivKey { xprv, kind })
@@ -165,7 +165,7 @@ impl ElectrumExtendedPrivKey {
             return Err(base58::Error::InvalidLength(data.len()).to_string());
         }
 
-        Ok(base58::check_encode_slice(&data))
+        Ok(base58::encode_check(&data))
     }
 }
 

--- a/src/electrum_wallet_file.rs
+++ b/src/electrum_wallet_file.rs
@@ -1,5 +1,5 @@
 use crate::{ElectrumExtendedKey, ElectrumExtendedPrivKey, ElectrumExtendedPubKey};
-use bitcoin::util::bip32::{ExtendedPrivKey, ExtendedPubKey};
+use bitcoin::bip32::{ExtendedPrivKey, ExtendedPubKey};
 use regex::Regex;
 use serde::{de, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, io::BufReader, path::Path, str::FromStr, string::ToString};


### PR DESCRIPTION
Updated also some other testing-related dependencies.

Since latest `miniscript` crate is still using `bitcoin` 0.29, `test_first_address()` had to be modified a bit.